### PR TITLE
Update CSV line breaks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -273,7 +273,7 @@ class CollectUserData {
     );
     await writeFileAsync(
       `${DATA_FOLDER}/${ARTIFACT_FILE_NAME}.csv`,
-      JSON.stringify(csv)
+      csv
     );
 
     await this.createandUploadArtifacts();

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ const os = require("os");
 function JSONtoCSV(json) {
   var keys = Object.keys(json[0]);
   var csv = keys.join(",") + os.EOL;
-
+  csv += "test";
   json.forEach(record => {
     keys.forEach((key, i) => {
       csv += record[key];

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,6 @@ const os = require("os");
 function JSONtoCSV(json) {
   var keys = Object.keys(json[0]);
   var csv = keys.join(",") + os.EOL;
-  csv += "test";
   json.forEach(record => {
     keys.forEach((key, i) => {
       csv += record[key];
@@ -13,7 +12,6 @@ function JSONtoCSV(json) {
     });
     csv += os.EOL;
   });
-
   return csv;
 }
 


### PR DESCRIPTION
Hey @SvanBoxel 👋 super excited about this action! When I was playing around with it, I had some trouble opening the CSV artifact file with excel and numbers. I'm guessing the lines weren't breaking because the output was stringified:

![Screen Shot 2020-04-10 at 10 43 18 PM](https://user-images.githubusercontent.com/1704143/79036402-c5a04e80-7b7c-11ea-8b85-f8b437dbb740.png)

Removing `JSON.stringify()` for `csv` fixed it for me:

![Screen Shot 2020-04-10 at 10 43 32 PM](https://user-images.githubusercontent.com/1704143/79036406-d224a700-7b7c-11ea-9ed9-47f282d2a1fd.png)

Hopefully this wouldn't break anything?